### PR TITLE
#10: parser should accept only instances of LocalDate and reject JS Dates (closes #10)

### DIFF
--- a/src/LocalDate.js
+++ b/src/LocalDate.js
@@ -16,8 +16,11 @@ export default class LocalDate extends Date {
     return LocalDate.ISO_DATE_FORMAT.test(isoDate);
   }
 
-  constructor(value = new Date()) {
-    if (value instanceof Date) {
+  constructor(value) {
+    if (typeof value === 'undefined') {
+      const now = new Date();
+      super(now.getFullYear(), now.getMonth(), now.getDate());
+    } else if (value instanceof LocalDate) {
       super(value.getFullYear(), value.getMonth(), value.getDate());
     } else if (typeof value === 'string' && LocalDate.ISO_DATE_FORMAT.test(value)) {
       const [

--- a/src/LocalDate.js
+++ b/src/LocalDate.js
@@ -30,9 +30,7 @@ export default class LocalDate extends Date {
       ] = LocalDate.ISO_DATE_FORMAT.exec(value).slice(1).map(s => parseInt(s, 10));
       super(year, month - 1, date, 0, 0, 0, 0);
     } else {
-      throw new Error(
-        'Invalid date supplied. Please specify a Date object or an ISO date string (YYYY-MM-DD).'
-      );
+      throw new Error('Invalid date supplied. Please specify an ISO date string (YYYY-MM-DD) or a LocalDate object.'); // eslint-disable-line max-len
     }
   }
 

--- a/test/tests/parser.test.js
+++ b/test/tests/parser.test.js
@@ -42,17 +42,11 @@ describe('Parser', () => {
     shouldNotConsiderTimeOrTimezone(localDate);
   });
 
-  it('Should parse JS Dates without considering any time or timezone', () => {
-    const year = 1991;
-    const month = 6;
-    const day = 4;
-    const jsDate = new Date(year, month - 1, day, 15, 30, 30);
-    const localDate = new LocalDate(jsDate);
+  it('Should clone instances of LocalDates', () => {
+    const localDate = new LocalDate('2016-05-20');
+    const clonedLocalDate = new LocalDate(localDate);
 
-    expect(localDate.getFullYear()).toEqual(year);
-    expect(localDate.getMonth()).toEqual(month - 1);
-    expect(localDate.getDate()).toEqual(day);
-    shouldNotConsiderTimeOrTimezone(localDate);
+    expect(localDate).toEqual(clonedLocalDate);
   });
 
   it('Should throw an error if argument is invalid', () => {
@@ -60,6 +54,7 @@ describe('Parser', () => {
       return new LocalDate(argument);
     };
 
+    expect(newLocalDate(new Date())).toThrow();
     expect(newLocalDate(null)).toThrow();
     expect(newLocalDate(1483549074687)).toThrow(); // timestamp
     expect(newLocalDate(2016, 5, 21)).toThrow();


### PR DESCRIPTION
Issue #10

## Test Plan

### tests performed
- CI should pass

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
