### PR TITLE
#28: add  static `test` and `ISO_REGEXP` to the TS typings (closes #28)

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,10 @@
 declare module 'local-date' {
-  export class LocalDate extends Date {}
-  export class LocalDateTime extends Date {}
+  export class LocalDate extends Date {
+    static ISO_DATE_FORMAT: RegExp;
+    static test(iso: string): boolean;
+  }
+  export class LocalDateTime extends Date {
+    static ISO_DATE_TIME_FORMAT: RegExp;
+    static test(iso: string): boolean;
+  }
 }


### PR DESCRIPTION
Closes [#2521033](https://buildo.kaiten.io/space/[object Object]/card/2521033)

⚠️ The line above was added during the automatic migration of all github project issues to Kaiten. The old GH issue link is kept here for reference (it is now deprecated, continue follow the original issue on Kaiten).

Closes #28

Still suboptimal, but this allow at least (from a TS project) to:
```ts
LocalDate.test('str') // false
```
instead of `try/catch`ing `new LocalDate('str')`

## Test Plan

### tests performed

> A Test Plan is used to show what you tested to make sure your code works fine. You should write here all that you did to test, and provide some results of your testing.

> These results can be screenshots, query results, or even just pointers to unit tests that successfully passed.

### tests not performed (domain coverage)

> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.
